### PR TITLE
Parse '@age' parameter property of gmodules self-description

### DIFF
--- a/actinia-module.md
+++ b/actinia-module.md
@@ -476,3 +476,16 @@ List / Describe combined
 Full API docs
 
 * http://127.0.0.1:8088/api/v1/swagger.json
+
+
+
+### 6. Additional Notes
+
+The self-description tries to comply the [openEO API](https://open-eo.github.io/openeo-api/apireference/#tag/Process-Discovery/paths/~1processes/get) where applicable.
+At some points, however, we have to divert from their API:
+
+* `returns` section may contain multiple outputs and has the same structure
+as the `parameters` sections.
+
+A parameter will only be added to the `returns` section if it contains the property `gisprompt.@age` and only if that value equals `'new'`. In all other cases, the parameter will be added to the `parameters` section.
+

--- a/actinia_gdi/core/gmodulesParser.py
+++ b/actinia_gdi/core/gmodulesParser.py
@@ -146,6 +146,21 @@ def setParameterEnum(parameter, schema_kwargs):
     return schema_kwargs
 
 
+def isOutput(parameter):
+    """ Checks if parameter is output parameter.
+    Returns True if parameter has key 
+    'gisprompt.age' == 'new',
+    False otherwise.
+    """
+    try:
+        if '@age' in parameter['gisprompt'].keys():
+            return (parameter['gisprompt']['@age'] == 'new')
+        else:
+            return False
+    except KeyError:
+        return False
+
+
 def ParseInterfaceDescription(xml_string, keys=None):
     """Parses output of GRASS interface-description
     and returns openEO process object
@@ -158,6 +173,7 @@ def ParseInterfaceDescription(xml_string, keys=None):
     categories = gm_dict['keywords'].replace(' ', '').split(',')
     categories.append('grass-module')
     parameters = {}
+    returns = {}
 
     try:
         grass_params = gm_dict['parameter']
@@ -193,7 +209,10 @@ def ParseInterfaceDescription(xml_string, keys=None):
             **kwargs,
             schema=ModuleParameterSchema(**schema_kwargs)
         )
-        parameters[key] = param_object
+        if isOutput(parameter):
+            returns[key] = param_object
+        else:
+            parameters[key] = param_object
         del kwargs
         del schema_kwargs
 
@@ -224,7 +243,8 @@ def ParseInterfaceDescription(xml_string, keys=None):
         id=module_id,
         description=description,
         categories=sorted(categories),
-        parameters=parameters
+        parameters=parameters,
+        returns=returns
     )
 
     return grass_module

--- a/actinia_gdi/core/gmodulesParser.py
+++ b/actinia_gdi/core/gmodulesParser.py
@@ -161,16 +161,6 @@ def isOutput(parameter):
         return False
 
 
-def getReturns(parameter):
-    returns = {}
-    return_keys = ['description', 'media_type', 'schema']
-    parameter_keys = parameter.keys()
-    for key in return_keys:
-        if key in parameter_keys:
-            returns[key] = parameter[key]
-    return returns
-
-
 def ParseInterfaceDescription(xml_string, keys=None):
     """Parses output of GRASS interface-description
     and returns openEO process object
@@ -220,7 +210,7 @@ def ParseInterfaceDescription(xml_string, keys=None):
             schema=ModuleParameterSchema(**schema_kwargs)
         )
         if isOutput(parameter):
-            returns = getReturns(param_object)
+            returns[key] = param_object
         else:
             parameters[key] = param_object
         del kwargs

--- a/actinia_gdi/core/gmodulesParser.py
+++ b/actinia_gdi/core/gmodulesParser.py
@@ -161,6 +161,16 @@ def isOutput(parameter):
         return False
 
 
+def getReturns(parameter):
+    returns = {}
+    return_keys = ['description', 'media_type', 'schema']
+    parameter_keys = parameter.keys()
+    for key in return_keys:
+        if key in parameter_keys:
+            returns[key] = parameter[key]
+    return returns
+
+
 def ParseInterfaceDescription(xml_string, keys=None):
     """Parses output of GRASS interface-description
     and returns openEO process object
@@ -210,7 +220,7 @@ def ParseInterfaceDescription(xml_string, keys=None):
             schema=ModuleParameterSchema(**schema_kwargs)
         )
         if isOutput(parameter):
-            returns[key] = param_object
+            returns = getReturns(param_object)
         else:
             parameters[key] = param_object
         del kwargs


### PR DESCRIPTION
Parses the `@age` property of all module parameters for the self-description. If this property exists and its value is `new`, the parameter will be added to the new `returns` section. In any other case, the parameter will be added to the `parameters` section.

Example:
```json
{
  "categories": [
    "general", 
    "grass-module", 
    "list", 
    "mapmanagement", 
    "search"
  ], 
  "description": "Lists available GRASS data base files of the user-specified data type optionally using the search pattern.", 
  "id": "g.list", 
  "parameters": {
    "e": {
      "description": ". Use extended regular expressions instead of wildcards", 
      "schema": {
        "default": "False", 
        "type": "boolean"
      }
    }, 
    "exclude": {
      "description": ". Map name exclusion pattern (default: none)", 
      "required": false, 
      "schema": {
        "type": "string"
      }
    }, 
    "f": {
      "description": ". Verbose listing (also list map titles)", 
      "schema": {
        "default": "False", 
        "type": "boolean"
      }
    }, 
    "help": {
      "description": ". Print usage summary", 
      "schema": {
        "default": "False", 
        "type": "boolean"
      }
    }, 
    "i": {
      "description": ". Ignore case", 
      "schema": {
        "default": "False", 
        "type": "boolean"
      }
    }, 
    "m": {
      "description": ". Print fully-qualified map names (including mapsets)", 
      "schema": {
        "default": "False", 
        "type": "boolean"
      }
    }, 
    "mapset": {
      "description": "Name of mapset to list (default: current search path). '.' for current mapset; '*' for all mapsets in location", 
      "required": false, 
      "schema": {
        "subtype": "mapset", 
        "type": "array"
      }
    }, 
    "overwrite": {
      "description": ". Allow output files to overwrite existing files", 
      "schema": {
        "default": "False", 
        "type": "boolean"
      }
    }, 
    "p": {
      "description": ". Pretty printing in human readable format", 
      "schema": {
        "default": "False", 
        "type": "boolean"
      }
    }, 
    "pattern": {
      "description": ". Map name search pattern (default: all)", 
      "required": false, 
      "schema": {
        "type": "string"
      }
    }, 
    "quiet": {
      "description": ". Quiet module output", 
      "schema": {
        "default": "False", 
        "type": "boolean"
      }
    }, 
    "r": {
      "description": ". Use basic regular expressions instead of wildcards", 
      "schema": {
        "default": "False", 
        "type": "boolean"
      }
    }, 
    "region": {
      "description": "Name of saved region for map search (default: not restricted). '.' for current region; '*' for default region", 
      "required": false, 
      "schema": {
        "subtype": "windows", 
        "type": "string"
      }
    }, 
    "separator": {
      "description": "Field separator. Special characters: pipe, comma, space, tab, newline", 
      "required": false, 
      "schema": {
        "default": "newline", 
        "subtype": "separator", 
        "type": "string"
      }
    }, 
    "t": {
      "description": ". Print data types", 
      "schema": {
        "default": "False", 
        "type": "boolean"
      }
    }, 
    "type": {
      "description": ". Data type(s)", 
      "required": true, 
      "schema": {
        "enum": [
          "raster", 
          "raster_3d", 
          "vector", 
          "label", 
          "region", 
          "group", 
          "all"
        ], 
        "type": "array"
      }
    }, 
    "verbose": {
      "description": ". Verbose module output", 
      "schema": {
        "default": "False", 
        "type": "boolean"
      }
    }
  }, 
  "returns": {
    "output": {
      "description": "Name for output file. If not given or '-' then standard output", 
      "required": false, 
      "schema": {
        "subtype": "file", 
        "type": "string"
      }
    }
  }
}
```