### PR TITLE
add elasticsearch, fluentd and kibana to plugin setup

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -9,11 +9,27 @@ Depending on how you run, it, actinia-gdi has different endpoints as some make o
 # As actinia-core plugin
 
 To run actinia-gdi with actinia-core, run
+
 ```
 docker-compose --file docker/docker-compose-plugin.yml build
 docker-compose --file docker/docker-compose-plugin.yml up
-# if a redis db is running locally this will fail. Run /etc/init.d/redis-server stop and try again
 ```
+
+To fix common startup errors:
+* if a redis db is running locally this will fail. Run and try again:
+```
+/etc/init.d/redis-server stop
+```
+* if elasticsearch is shutting down immediately, check logs with
+```
+docker logs docker_elasticsearch_1
+```
+  if you see an error like "max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]", run
+```
+sudo sysctl -w vm.max_map_count=262144
+```
+  this is only valid on runtime. To change permanently, set vm.max_map_count in /etc/sysctl.conf
+
 
 To run actinia-gdi with actinia-core only based on ready-to-use images, run
 ```
@@ -76,6 +92,7 @@ cd -
 grass /actinia_core/grassdb/nc_spm_08/PERMANENT
 ```
 
+To reach kibana (only setup in docker-compose-plugin.yml), open http://127.0.0.1:5601 in your browser.
 
 
 

--- a/docker/docker-compose-plugin.yml
+++ b/docker/docker-compose-plugin.yml
@@ -43,9 +43,6 @@ services:
     build:
       context: fluentd
     image: fluentd
-    ports:
-      - "24224:24224"
-      - "24224:24224/udp"
     expose:
       - 24224
 
@@ -53,9 +50,6 @@ services:
     image:  elasticsearch:7.4.0
     environment:
     - discovery.type=single-node
-    ports:
-      - 9200:9200
-      - 9300:9300
 
   kibana:
     image: kibana:7.4.0

--- a/docker/docker-compose-plugin.yml
+++ b/docker/docker-compose-plugin.yml
@@ -18,6 +18,9 @@ services:
       - 8088
     depends_on:
       - redis
+      - fluentd
+      - elasticsearch
+      - kibana
 
   redis:
     image: redis:5.0.4-alpine
@@ -35,3 +38,26 @@ services:
     ]
     ports:
       - 6379:6379
+
+  fluentd:
+    build:
+      context: fluentd
+    image: fluentd
+    ports:
+      - "24224:24224"
+      - "24224:24224/udp"
+    expose:
+      - 24224
+
+  elasticsearch:
+    image:  elasticsearch:7.4.0
+    environment:
+    - discovery.type=single-node
+    ports:
+      - 9200:9200
+      - 9300:9300
+
+  kibana:
+    image: kibana:7.4.0
+    ports:
+      - "5601:5601"

--- a/docker/fluentd/Dockerfile
+++ b/docker/fluentd/Dockerfile
@@ -1,0 +1,4 @@
+FROM fluent/fluentd
+RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-rdoc", "--no-ri", "--version", "3.5.5"]
+RUN rm /fluentd/etc/fluent.conf
+COPY fluent.conf /fluentd/etc

--- a/docker/fluentd/fluent.conf
+++ b/docker/fluentd/fluent.conf
@@ -1,0 +1,34 @@
+# fluent.conf
+<source>
+  @type forward
+  port 24224
+  bind 0.0.0.0
+</source>
+<match *.**>
+  @type copy
+  <store>
+    @type elasticsearch
+    host elasticsearch
+    port 9200
+    logstash_format true
+    logstash_prefix fluentd
+    logstash_dateformat %Y%m%d
+    include_tag_key true
+    type_name access_log
+    tag_key @log_name
+    flush_interval 1s
+  </store>
+  <store>
+    @type file
+    @id   output1
+    path         /fluentd/log/data.*.log
+    symlink_path /fluentd/log/data.log
+    append       true
+    time_slice_format %Y%m%d
+    time_slice_wait   10m
+    time_format       %Y%m%dT%H%M%S%z
+  </store>
+</match>
+<filter **>
+  @type stdout
+</filter>


### PR DESCRIPTION
As actinia-core already has a fluentd logger integrated, we make use of it and are enabled to view logs and stats nicely.
![sample-kibana](https://user-images.githubusercontent.com/8308401/66397057-55511e80-e9db-11e9-9bcb-bcf4fb1fe8ee.jpeg)
