### PR TITLE
actinia-module attribute renaming

### DIFF
--- a/actinia_gdi/api/gdi_ephemeral_processing_with_export.py
+++ b/actinia_gdi/api/gdi_ephemeral_processing_with_export.py
@@ -38,13 +38,12 @@ from actinia_core.resources.common.redis_interface import enqueue_job
 from actinia_core.resources.common.process_object import Process
 from actinia_core.resources.common.process_chain import ProcessChainModel
 from actinia_core.resources.common.exceptions import AsyncProcessTermination
-from actinia_core.resources.common.response_models import ProcessingResponseModel, ProcessingErrorResponseModel
+from actinia_core.resources.common.response_models import ProcessingResponseModel, ProcessingErrorResponseModel, SimpleResponseModel
 
 # from actinia_gdi.api.gmodules.grass import ListModules
 from actinia_gdi.core.gmodulesActinia import createProcessChainTemplateList
 from actinia_gdi.core.gmodulesActinia import fillTemplateFromProcessChain
 from actinia_gdi.core.gmodulesGrass import createModuleList
-from actinia_gdi.model.responseModels import SimpleStatusCodeResponseModel
 
 
 __license__ = "GPLv3"
@@ -157,21 +156,21 @@ class GdiAsyncEphemeralExportResource(ResourceBase):
                             return make_response(jsonify(SimpleResponseModel(
                                 status="error",
                                 message=msg
-                            )), 409)
+                            )), 400)
                         elif module_pc is None:
                             msg = "Invalid request for %s" % (name)
                             return make_response(jsonify(SimpleResponseModel(
                                 status="error",
                                 message=msg
-                            )), 409)
+                            )), 400)
                         else:
                             new_pc.extend(module_pc)
                     else:
                         msg = "Module %s is not of type importer, exporter, grass-module or an actinia-module." % name
-                        return make_response(jsonify(SimpleStatusCodeResponseModel(
+                        return make_response(jsonify(SimpleResponseModel(
                             status="error",
                             message=msg
-                        )), 409)
+                        )), 400)
                 else:
                     new_pc.append(module)
 

--- a/actinia_gdi/core/gmodulesParser.py
+++ b/actinia_gdi/core/gmodulesParser.py
@@ -251,7 +251,8 @@ def ParseInterfaceDescription(xml_string, keys=None):
             for param in pc_template[key]:
                 extrakwargs[key][param] = ModuleParameter(**pc_template[key][param])
     except Exception as e:
-        log.debug(e)
+        # if no template for module exist, use as is (default)
+        log.debug('template %s does not exist.', e)
 
     grass_module = Module(
         id=module_id,

--- a/actinia_gdi/model/gmodules.py
+++ b/actinia_gdi/model/gmodules.py
@@ -83,6 +83,10 @@ class ModuleParameter(Schema):
             'description': 'Determines whether this parameter is mandatory. Default: false'
         },
         'schema': ModuleParameterSchema
+        # 'comment': {
+        #     'type': 'string',
+        #     'description': 'Comment for parameter.'
+        # }
     }
     description = 'A list of parameters that are applicable for this process.'
     required = ["description", "schema"]

--- a/actinia_gdi/templates/pc_templates/vector_area.json
+++ b/actinia_gdi/templates/pc_templates/vector_area.json
@@ -6,8 +6,10 @@
             {
                 "id": "copy_vector_data",
                 "module": "g.copy",
+                "comment": "Copies a map",
                 "inputs": [
                     {
+                        "comment": "name of map to be copied and name of new copy.",
                         "param": "vector",
                         "value": "{{ name_and_copy }}"
                     }


### PR DESCRIPTION
This PR renames the actinia-module attributes to placeholder names in the module self-description. Before they were named after the used grass-module and the attribute of the module. This might be misleading if a placeholder is used twice (then the first-time use was taken for self-description). Now it is named like the placeholder variable in the template which gives the template creator more control over the self-description.
The "start-process" endpoint was also updated to now parse process chains with these new attributes.