### PR TITLE
fix parser for actinia-module self-description

### DIFF
--- a/actinia_gdi/core/gmodulesActinia.py
+++ b/actinia_gdi/core/gmodulesActinia.py
@@ -79,7 +79,10 @@ def createProcessChainTemplateList():
 
     for tpl_string in tpl_list:
         tpl = pcTplEnv.get_template(tpl_string)
-        pc_template = json.loads(tpl.render().replace('\n', ''))
+        try:
+            pc_template = json.loads(tpl.render().replace('\n', ''))
+        except:
+            log.error('Error parsing template ' + tpl_string)
 
         tpl_id = pc_template['id']
         description = pc_template['description']

--- a/actinia_gdi/core/gmodulesParser.py
+++ b/actinia_gdi/core/gmodulesParser.py
@@ -196,10 +196,12 @@ def ParseInterfaceDescription(xml_string, keys=None):
         schema_kwargs = dict()
 
         if keys:
+            # case for actinia modules
             key = setVirtualParameterKey(module_id, parameter)
             if key not in keys:
                 continue
         else:
+            # case for GRASS modules
             key = setParameterKey(module_id, parameter)
 
         schema_kwargs = setParamType(module_id, key, parameter, schema_kwargs)


### PR DESCRIPTION
For advanced PC templates the parser did reach its limits. E.g. when using a placeholder for only a part of the value, it did crash. Here an example for an r.mapcalc expression `"slope_ok = if(slope <= {{ slope_max_deg }}, 1, null() )"` did not appear in the self-description and the example `"{{ resultmap }} = round(optimal_areas_ranked_tmp)"` leaded to 
```
    "resultmap }} = round(optimal_areas_ranked_tmp)": {
      "description": ". Expression to evaluate [generated from r.mapcalc_expression]",
      "required": false,
      "schema": {
        "type": "string"
      }
    },
```
This PR fixes this.
At the same time it was rewritten to not request all GRASS GIS module interface-descriptions of the process chain at the same time, but only the ones containing placeholders in a loop.