### PR TITLE
support subfolders for pc_templates

### DIFF
--- a/actinia_gdi/core/gmodulesActinia.py
+++ b/actinia_gdi/core/gmodulesActinia.py
@@ -53,8 +53,15 @@ def filter_func(name):
 
 def renderTemplate(pc):
 
+    tplPath = pc + '.json'
+
+    # change path to template if in subdir
+    for i in pcTplEnv.list_templates():
+        if i.split('/')[-1] == tplPath:
+            tplPath = i
+
     # find variables from processchain and render template with variables
-    tpl_source = pcTplEnv.loader.get_source(pcTplEnv, pc + '.json')[0]
+    tpl_source = pcTplEnv.loader.get_source(pcTplEnv, tplPath)[0]
     parsed_content = pcTplEnv.parse(tpl_source)
     # {'column_name', 'name'}
     undef = meta.find_undeclared_variables(parsed_content)
@@ -63,7 +70,7 @@ def renderTemplate(pc):
     for i in undef:
         kwargs[i] = '{{ ' + i + ' }}'
 
-    tpl = pcTplEnv.get_template(pc + '.json')
+    tpl = pcTplEnv.get_template(tplPath)
     pc_template = json.loads(tpl.render(**kwargs).replace('\n', ''))
 
     return pc_template


### PR DESCRIPTION
With this PR, all pc_templates not only in `actinia_gdi/templates/pc_templates` can be requested for self-description, but also templates in subdirectories, except examples folder. All templates will be listed when requesting `/modules` endpoint and description will be loaded when `/modules/<module>` is requested. This way, new templates can be mounted at deployment time.