### PR TITLE
add travis ci to deploy wheel for release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ cover/*
 MANIFEST
 
 # Development env
+dev
 venv/
 showcase
 config/mount/config.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+
+python: 3.6
+
+install:
+  - pip3 install --upgrade pip pep517 wheel
+
+jobs:
+  include:
+    - stage: build
+      script: python3 -m pep517.build --out-dir build .
+
+deploy:
+  provider: releases
+  api_key: "$GITHUB_OAUTH_TOKEN"
+  file_glob: true
+  file: build/*.whl
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
After a actinia-gdi release, the travis will automatically create a wheel and add it to the release.