### PR TITLE
Add exe to self-description

### DIFF
--- a/actinia_gdi/core/gmodulesActinia.py
+++ b/actinia_gdi/core/gmodulesActinia.py
@@ -140,6 +140,7 @@ def createActiniaModule(self, processchain):
     processes = pc_template['template']['list']
 
     aggregated_vals = []
+    aggregated_exes = []
     input_dict = {}
     import_descr_dict = {}
     exporter_dict = {}
@@ -148,6 +149,13 @@ def createActiniaModule(self, processchain):
     for i in processes:
 
         # create the exec_process_chain item
+        if 'exe' in i and 'params' in i:
+            for j in i['params']:
+                if '{{ ' in j and ' }}' in j and j not in aggregated_exes:
+                    placeholder = re.search(r"\{\{(.*?)\}\}", j).groups()[0].strip(' ')
+                    if placeholder not in aggregated_exes:
+                        aggregated_exes.append(placeholder)
+            continue
         module = i['module']
         processid = i['id']
         # TODO: display this in module description?
@@ -237,10 +245,13 @@ def createActiniaModule(self, processchain):
             for param in grass_module['returns']:
                 if param in aggregated_keys.keys():
                     amkey = aggregated_keys[param]['amkey']
-                    virtual_module_returns[amkey] = grass_module['returns'][param]
+                    if amkey in virtual_module_params:
+                        pass
+                    else:
+                        virtual_module_returns[amkey] = grass_module['returns'][param]
 
-                    add_param_description(
-                        virtual_module_returns[amkey], param, input_dict)
+                        add_param_description(
+                            virtual_module_returns[amkey], param, input_dict)
 
         if 'import_descr' in grass_module:
             for param in grass_module['import_descr']:
@@ -259,6 +270,16 @@ def createActiniaModule(self, processchain):
 
                         add_param_description(
                             virtual_module_returns[key], 'exporter' + param, exporter_dict)
+
+    # add parameters from executable
+    for param in aggregated_exes:
+        exe_param = {}
+        exe_param['description'] = 'Simple parameter from executable'
+        exe_param['required'] = True
+        exe_param['schema'] = {'type': 'string'}
+        add_param_description(
+            exe_param, 'exe', dict())
+        virtual_module_params[param] = exe_param
 
     virtual_module = Module(
         id=pc_template['id'],


### PR DESCRIPTION
This PR adds the option to integrate not only GRASS GIS modules but processes of type `exe` into an actinia-module. The self description will be generated for module self-description and and placeholders will be replaced on process execution.

Example for module self-description:
```

{
  "categories": [
    "actinia-module"
  ],
  "description": "Calculates Quicklook and bandmath with orbit-, thermalnoise-, radiometric and terrain correction with export.",
  "id": "r_s1_grd",
  "parameters": {
    "esahub_pw": {
      "description": "Simple parameter from executable [generated from exe]",
      "required": true,
      "schema": {
        "type": "string"
      }
    },
    "esahub_user": {
      "description": "Simple parameter from executable [generated from exe]",
      "required": true,
      "schema": {
        "type": "string"
      }
    },
    "s1_scene_name": {
      "description": "Simple parameter from executable [generated from exe]",
      "required": true,
      "schema": {
        "type": "string"
      }
    }
  },
  "returns": {}
}
```
the according pc_template looks like this:
```
{
    "id": "r_s1_grd",
    "description": "Calculates Quicklook and bandmath with orbit-, thermalnoise-, radiometric and terrain correction with export.",
    "template": {
        "version": "1",
        "list": [
            {
                "id": "download",
                "exe": "sentinelsat",
                "params": [
                    "-u", "{{ esahub_user }}",
                    "-p", "{{ esahub_pw }}",
                    "--name", "{{ s1_scene_name }}",
                    "-d",
                    "--path", "/mnt/geodata/sentinel1/raw"
                ]
            },
...
```

Additionally, this PR removes a duplicate entry, if output placeholder is already described in input placeholder. Before, the same placeholder was listed twice, if used in input and output.