### PR TITLE
add parameter description for parameters in one line/GRASS GIS parameter

### DIFF
--- a/actinia_gdi/core/gmodulesActinia.py
+++ b/actinia_gdi/core/gmodulesActinia.py
@@ -174,17 +174,27 @@ def createActiniaModule(self, processchain):
             if '{{ ' in val and ' }}' in val and val not in aggregated_vals:
                 aggregated_vals.append(val)
                 run_interface_descr = True
-                input_dict[processid]["gparams"][key] = {}
 
                 # matches placeholder in longer value, e.g. in
                 # 'res = if(input <= {{ my_values }}, 1, null() )'
                 # beware that in general it is easier to make the whole value
                 # a placeholder. Might be not possible for e.g. r.mapcalc
-                placeholder = re.search(r"\{\{(.*?)\}\}", str(val)).groups()[0]
-                amkey = placeholder.strip(' ')
-                input_dict[processid]["gparams"][key]['amkey'] = amkey
-                if 'comment' in j:
-                    input_dict[processid]["gparams"][key]['comment'] = j['comment']
+                placeholders = re.findall(r"\{\{(.*?)\}\}", str(val))
+
+                if len(placeholders) == 1:
+                    input_dict[processid]["gparams"][key] = {}
+                    amkey = placeholders[0].strip(' ')
+                    input_dict[processid]["gparams"][key]['amkey'] = amkey
+                    if 'comment' in j:
+                        input_dict[processid]["gparams"][key]['comment'] = j['comment']
+                else:
+                    for placeholder in placeholders:
+                        amkey = placeholder.strip(' ')
+                        newkey = "%s_%s" % (key, amkey)
+                        input_dict[processid]["gparams"][newkey] = {}
+                        input_dict[processid]["gparams"][newkey]['amkey'] = amkey
+                        if 'comment' in j:
+                            input_dict[processid]["gparams"][newkey]['comment'] = j['comment']
 
             if 'import_descr' in j:
                 for key, val in j['import_descr'].items():
@@ -223,6 +233,7 @@ def createActiniaModule(self, processchain):
             xml_string,
             keys=aggregated_keys.keys()
         )
+        import pdb; pdb.set_trace()
 
         if 'parameters' in grass_module:
             for param in grass_module['parameters']:

--- a/actinia_gdi/core/gmodulesActinia.py
+++ b/actinia_gdi/core/gmodulesActinia.py
@@ -110,12 +110,17 @@ def add_param_description(moduleparameter, param, input_dict):
     # update description and mention grass module parameter
     suffix = " [generated from " + param + "]"
     moduleparameter['description'] += suffix
-    # add comment if there is one in process chain template
 
+    # add comment if there is one in process chain template
+    if not param in input_dict:
+        for input_dict_key in input_dict:
+            if param in input_dict_key:
+                param = input_dict_key
     if param in input_dict and 'comment' in input_dict[param]:
         comment = input_dict[param]['comment']
-        moduleparameter['description'] += " - " + comment
-        # moduleparameter['comment'] = comment
+        if comment not in moduleparameter['description']:
+            moduleparameter['description'] += " - " + comment
+            # moduleparameter['comment'] = comment
 
 
 def createActiniaModule(self, processchain):
@@ -241,16 +246,16 @@ def createActiniaModule(self, processchain):
             xml_string,
             keys=aggregated_keys.keys()
         )
-        import pdb; pdb.set_trace()
 
         if 'parameters' in grass_module:
             for param in grass_module['parameters']:
-                if param in aggregated_keys.keys():
-                    amkey = aggregated_keys[param]['amkey']
-                    virtual_module_params[amkey] = grass_module['parameters'][param]
+                for aggregated_key in aggregated_keys:
+                    if param in aggregated_key:
+                        amkey = aggregated_keys[aggregated_key]['amkey']
+                        virtual_module_params[amkey] = grass_module['parameters'][param]
 
-                    add_param_description(
-                        virtual_module_params[amkey], param, aggregated_keys)
+                        add_param_description(
+                            virtual_module_params[amkey], param, aggregated_keys)
 
         if 'returns' in grass_module:
             for param in grass_module['returns']:

--- a/actinia_gdi/core/gmodulesParser.py
+++ b/actinia_gdi/core/gmodulesParser.py
@@ -198,8 +198,14 @@ def ParseInterfaceDescription(xml_string, keys=None):
         if keys:
             # case for actinia modules
             key = setVirtualParameterKey(module_id, parameter)
-            import pdb;pdb.set_trace()
+            key_exists = False
             if key not in keys:
+                for actiniakey in keys:
+                    if actiniakey.startswith(key):
+                        key_exists = True
+            else:
+                key_exists = True
+            if not key_exists:
                 continue
         else:
             # case for GRASS modules

--- a/actinia_gdi/core/gmodulesParser.py
+++ b/actinia_gdi/core/gmodulesParser.py
@@ -198,6 +198,7 @@ def ParseInterfaceDescription(xml_string, keys=None):
         if keys:
             # case for actinia modules
             key = setVirtualParameterKey(module_id, parameter)
+            import pdb;pdb.set_trace()
             if key not in keys:
                 continue
         else:

--- a/actinia_gdi/templates/pc_templates/default_value.json
+++ b/actinia_gdi/templates/pc_templates/default_value.json
@@ -10,6 +10,7 @@
 				"inputs": [
 					{
 						"param": "expression",
+						"comment": "output = r.mapcalc result, string; value = raster value (default=0.428), float",
 						"value": "{{ output }} = {{ value|default(0.428) }}"
 					}
 			  ]


### PR DESCRIPTION
With this changes we get an description for each varibable (even though these are in one GRASS GIS parameter) in the actinia templates.
E.g. for the pc-template:
`{
	"id": "default_value",
	"description": "test default value in actinia-gdi",
	"template": {
		"version": "1",
		"list": [
			{
				"module": "r.mapcalc",
				"id": "r.mapcalc_test",
				"inputs": [
					{
						"param": "expression",
						"comment": "output = r.mapcalc result, string; value = raster value (default=0.428), float",
						"value": "{{ output }} = {{ value|default(0.428) }}"
					}
			  ]
			}
		]
	}
}
`
we get:
`{
categories: [
"actinia-module"
],
description: "test default value in actinia-gdi",
id: "default_value",
parameters: {
output: {
description: ". Expression to evaluate [generated from r.mapcalc_expression] - output = r.mapcalc result; value = raster value (default=0.428) [generated from r.mapcalc_expression]",
required: false,
schema: {
type: "string"
}
},
value: {
description: ". Expression to evaluate [generated from r.mapcalc_expression] - output = r.mapcalc result; value = raster value (default=0.428) [generated from r.mapcalc_expression]",
required: false,
schema: {
type: "string"
}
}
},
returns: { }
}`