### PR TITLE
add filtering of varibales with default values

### DIFF
--- a/actinia_gdi/core/gmodulesActinia.py
+++ b/actinia_gdi/core/gmodulesActinia.py
@@ -26,7 +26,7 @@ Module management related to process chain templates
 
 """
 import json
-from jinja2 import meta
+from jinja2 import meta, nodes
 import re
 
 from actinia_gdi.core.gmodulesProcessor import run_process_chain
@@ -292,6 +292,37 @@ def createActiniaModule(self, processchain):
     return virtual_module
 
 
+def find_filters(ast):
+    """Find all the nodes of a given type.  If the type is a tuple,
+    the check is performed for any of the tuple items.
+    Function from: https://stackoverflow.com/questions/55275399/how-to-get-variables-along-with-their-filter-name-from-jinja2-template
+    """
+    for child in ast.iter_child_nodes():
+        if isinstance(child, nodes.Filter):
+            yield child
+        else:
+            for result in find_filters(child):
+                yield result
+
+
+def filtered_variables(ast):
+    """Return variables that have filters, along with their filters. might
+    return duplicate variable names with different filters
+    Function from: https://stackoverflow.com/questions/55275399/how-to-get-variables-along-with-their-filter-name-from-jinja2-template
+    """
+    results = []
+    for i, node in enumerate(find_filters(ast)):
+        filters = []
+        f = node
+        filters.append(f.name)
+        while isinstance(f.node, nodes.Filter):
+            f = f.node
+            filters.append(f.name)
+        filters.reverse()
+        results.append((f.node.name, filters))
+    return results
+
+
 def fillTemplateFromProcessChain(module):
     """ This method receives a process chain for an actinia module and loads
         the according process chain template. The received values will be
@@ -327,8 +358,15 @@ def fillTemplateFromProcessChain(module):
     parsed_content = pcTplEnv.parse(tpl_source)
     undef = meta.find_undeclared_variables(parsed_content)
 
+    # find default variables from processchain
+    default_vars = []
+    filtered_vars = filtered_variables(parsed_content)
+    for filtered_var in filtered_vars:
+        if 'default' in filtered_var[1]:
+            default_vars.append(filtered_var[0])
+
     for i in undef:
-        if i not in kwargs.keys():
+        if i not in kwargs.keys() and not i in default_vars:
             log.error('Required parameter "' + i + '" not in process chain!')
             return i
 

--- a/actinia_gdi/templates/pc_templates/default_value.json
+++ b/actinia_gdi/templates/pc_templates/default_value.json
@@ -1,0 +1,19 @@
+{
+	"id": "default_value",
+	"description": "test default value in actinia-gdi",
+	"template": {
+		"version": "1",
+		"list": [
+			{
+				"module": "r.mapcalc",
+				"id": "r.mapcalc_test",
+				"inputs": [
+					{
+						"param": "expression",
+						"value": "{{ output }} = {{ value|default(0.428) }}"
+					}
+			  ]
+			}
+		]
+	}
+}

--- a/actinia_gdi/templates/pc_templates/examples/pc_default_value.json
+++ b/actinia_gdi/templates/pc_templates/examples/pc_default_value.json
@@ -1,0 +1,55 @@
+{
+    "list": [
+        {
+            "id": "g.region_red",
+            "module": "g.region",
+            "inputs": [
+                {
+                    "param": "n",
+                    "value": "228527.25"
+                },
+                {
+                    "param": "s",
+                    "value": "215018.25"
+                },
+                {
+                    "param": "w",
+                    "value": "629980"
+                },
+                {
+                    "param": "e",
+                    "value": "644971"
+                },
+                {
+                    "param": "res",
+                    "value": "30"
+                }
+            ]
+        },
+        {
+            "id": "test_default_values",
+            "module": "default_value",
+            "inputs": [
+                {
+                    "param": "output",
+                    "value": "test_defval"
+                }
+            ]
+        },
+        {
+            "id": "test_other_values",
+            "module": "default_value",
+            "inputs": [
+                {
+                    "param": "output",
+                    "value": "test_val"
+                },
+                {
+                    "param": "value",
+                    "value": "5"
+                }
+            ]
+        }
+    ],
+    "version": "1"
+}

--- a/docker/README.md
+++ b/docker/README.md
@@ -40,14 +40,14 @@ docker-compose --file docker/docker-compose-plugin-prod.yml up
 For actinia-gdi development, run and enter the running container.
 ```
 docker-compose --file docker/docker-compose-plugin.yml run --rm \
-  --service-ports -w /src/actinia-gdi --entrypoint bash \
+  --service-ports -w /src/actinia-gdi --entrypoint sh \
   -v $HOME/repos/actinia/actinia-gdi/actinia_gdi:/src/actinia-gdi/actinia_gdi actinia-core
 ```
 
 And run the actinia-core server with your mounted source code:
 ```
 python3 setup.py install
-bash /src/start-dev.sh
+sh /src/start-dev.sh
 
 # python3 -m actinia_core.main
 gunicorn -b 0.0.0.0:8088 -w 1 --access-logfile=- -k gthread actinia_core.main:flask_app

--- a/docker/actinia-core/Dockerfile
+++ b/docker/actinia-core/Dockerfile
@@ -17,7 +17,7 @@ COPY docker/actinia-core/actinia.cfg /etc/default/actinia
 COPY docker/actinia-core/start.sh /src/start.sh
 COPY docker/actinia-core/start-dev.sh /src/start-dev.sh
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/bin/sh"]
 CMD ["/src/start.sh"]
 
 ENV GISBASE ""


### PR DESCRIPTION
With this change you can use default values for variables in the actinia process chain templates.
The  default values in a template can be used like this:

- pc-template (actinia_gdi/templates/pc_templates/default_value.json ):
`{
	"id": "default_value",
	"description": "test default value in actinia-gdi",
	"template": {
		"version": "1",
		"list": [
			{
				"module": "r.mapcalc",
				"id": "r.mapcalc_test",
				"inputs": [
					{
						"param": "expression",
						"value": "{{ output }} = {{ value|default(0.428) }}"
					}
			  ]
			}
		]
	}
}`
- example pc which uses the pc-template (actinia_gdi/templates/pc_templates/examples/pc_default_value.json):
`{
    "list": [
        {
            "id": "g.region_red",
            "module": "g.region",
            "inputs": [
                {
                    "param": "n",
                    "value": "228527.25"
                },
                {
                    "param": "s",
                    "value": "215018.25"
                },
                {
                    "param": "w",
                    "value": "629980"
                },
                {
                    "param": "e",
                    "value": "644971"
                },
                {
                    "param": "res",
                    "value": "30"
                }
            ]
        },
        {
            "id": "test_default_values",
            "module": "default_value",
            "inputs": [
                {
                    "param": "output",
                    "value": "test_defval"
                }
            ]
        },
        {
            "id": "test_other_values",
            "module": "default_value",
            "inputs": [
                {
                    "param": "output",
                    "value": "test_val"
                },
                {
                    "param": "value",
                    "value": "5"
                }
            ]
        }
    ],
    "version": "1"
}
`

Additionally, I made some small changes and replaced bash with sh.