### PR TITLE
Nested actiniamodules

### DIFF
--- a/actinia_gdi/core/gmodulesParser.py
+++ b/actinia_gdi/core/gmodulesParser.py
@@ -68,13 +68,13 @@ def setParameterDescription(module_id, key, parameter, kwargs):
     param_descr = ""
 
     try:
-        param_descr = parameter['label']
+        param_descr = parameter['label'] + ". "
         kwargs['description'] = param_descr
     except KeyError:
         # logstring(module_id, key, "label")
         pass
     try:
-        param_descr += '. ' + parameter['description']
+        param_descr += parameter['description'] + ". "
         kwargs['description'] = param_descr
     except KeyError:
         logstring(module_id, key, "description")

--- a/actinia_gdi/templates/pc_templates/index_NDVI.json
+++ b/actinia_gdi/templates/pc_templates/index_NDVI.json
@@ -1,0 +1,35 @@
+{
+	"id": "index_NDVI",
+	"description": "Normalised Difference Vegetation Index (NDVI)",
+	"template": {
+		"version": "1",
+		"list": [
+			{
+				"module": "r.mapcalc",
+				"id": "r.mapcalc_ndvi",
+				"comment": "NDVI = ( NIR - RED ) / ( NIR + RED )",
+				"inputs": [
+					{
+						"param": "expression",
+						"value": "{{ output }} = float( {{ nir }} - {{ red }} ) / float( {{ nir }} + {{ red }} )"
+					}
+			  ]
+			},
+			{
+				"module": "r.colors",
+				"id": "r.colors_ndvi",
+				"inputs":
+				[
+					{
+						"param": "map",
+						"value": "{{ output }}"
+					},
+					{
+						"param": "color",
+						"value": "ndvi"
+					}
+				]
+			}
+		]
+	}
+}

--- a/actinia_gdi/templates/pc_templates/nested_modules_test.json
+++ b/actinia_gdi/templates/pc_templates/nested_modules_test.json
@@ -1,0 +1,88 @@
+{
+	"id": "nested_modules_test",
+	"description": "PC makes no sense but includes a lot of cases for testing self-description",
+	"template": {
+		"list": [
+			{
+				"id": "import_training_data",
+				"comment": "Tested with layers: actinia_data.trdata_polygons and actinia_data.trdata_points",
+				"module": "v.import",
+				"inputs": [
+					{
+						"param": "input",
+						"value": "{{ db_connection }}"
+					},
+					{
+						"param": "layer",
+						"value": "{{ layer }}"
+					},
+					{
+						"param": "output",
+						"value": "user_tr_data"
+					}
+				]
+			},
+			{
+				"id": "index_NDVI",
+				"module": "index_NDVI",
+				"inputs": [
+					{
+						"param": "output",
+						"value": "ndvi"
+					},
+					{
+						"param": "red",
+						"value": "{{ B04_mosaic }}"
+					},
+					{
+						"param": "nir",
+						"value": "B08_mosaic"
+					}
+				]
+			},
+			{
+				"id": "slope_aspect",
+				"module": "slope_aspect",
+				"inputs": [
+					{
+						"param": "datatype",
+						"value": "FCELL"
+					},
+					{
+						"param": "name_of_output_slope",
+						"value": "{{ output_slope_name }}"
+					},
+					{
+						"param": "name_of_output_aspect",
+						"value": "aspect"
+					}
+				]
+			},
+			{
+				"id": "point_in_polygon",
+				"module": "point_in_polygon",
+				"inputs": [
+					{
+						"param": "url_to_geojson_point",
+						"value": "{{ url_to_geojson_point }}"
+					}
+				]
+			},
+			{
+				"id": "r_colors",
+				"module": "r.colors",
+				"inputs": [
+					{
+						"param": "map",
+						"value": "{{ output }}"
+					},
+					{
+						"param": "color",
+						"value": "random"
+					}
+				]
+			}
+		],
+		"version": "1"
+	}
+}


### PR DESCRIPTION
This PR

- fixes #33
- enhances description of parameters
- refactors gmodulesActinia module
- adds test pc_templates

As an example, the "nested_modules_test" PC-Template (makes no sense calculating but demonstrates the self-description engine) would be displayed like this:
http://127.0.0.1:8088/api/v1/actiniamodules/nested_modules_test
```
{
  "categories": [
    "actinia-module"
  ],
  "description": "PC Makes no sense but includes a lot of cases for testing",
  "id": "nested_modules_test",
  "parameters": {
    "B04_mosaic": {
      "description": "Expression to evaluate.  [generated from r.mapcalc_expression]",
      "required": false,
      "schema": {
        "type": "string"
      }
    },
    "db_connection": {
      "description": "Name of OGR datasource to be imported.  [generated from v.import_input]",
      "required": true,
      "schema": {
        "subtype": "datasource",
        "type": "string"
      }
    },
    "layer": {
      "description": "OGR layer name. If not given, all available layers are imported.  [generated from v.import_layer]",
      "required": false,
      "schema": {
        "subtype": "datasource_layer",
        "type": "array"
      }
    },
    "output": {
      "description": "Name of raster map(s).  [generated from r.colors_map]",
      "required": false,
      "schema": {
        "subtype": "cell",
        "type": "array"
      }
    },
    "url_to_geojson_point": {
      "description": "The input source that may be a landsat scene name, a sentinel2 scene name, a postGIS database string, or an URL that points to an accessible raster or vector file [generated from import_descr_source]",
      "required": false,
      "schema": {
        "type": "string"
      }
    }
  },
  "returns": {
    "output_slope_name": {
      "description": "Name for output slope raster map.  [generated from r.slope.aspect_slope]",
      "required": false,
      "schema": {
        "subtype": "cell",
        "type": "string"
      }
    }
  }
}
```