### PR TITLE
Unify python file header

### DIFF
--- a/actinia_gdi/api/gdi_processing.py
+++ b/actinia_gdi/api/gdi_processing.py
@@ -1,5 +1,22 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#######
+"""
+Copyright (c) 2018-present mundialis GmbH & Co. KG
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Code based on actinia_core: github.com/mundialis/actinia_core
+
 # actinia-core - an open source REST API for scalable, distributed, high
 # performance processing of geographical data that uses GRASS GIS for
 # computational tasks. For details, see https://actinia.mundialis.de/
@@ -19,11 +36,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-#######
 
-"""
+
 Extension of actinia_cores ephemeral_processing_with_export AsyncEphemeralExportResource to include process chain templates
 """
+
+__license__ = "Apache-2.0"
+__author__ = "Anika Bettge, Sören Gebbert"
+__copyright__ = "Copyright 2016-2018, Sören Gebbert and mundialis GmbH & Co. KG"
+__maintainer__ = "mundialis"
+
+
 import pickle
 import time
 from flask import jsonify, make_response
@@ -40,11 +63,6 @@ from actinia_core.resources.common.response_models import create_response_from_m
 from actinia_gdi.core.gmodulesActinia import createProcessChainTemplateList
 from actinia_gdi.core.gmodulesActinia import fillTemplateFromProcessChain
 from actinia_gdi.core.gmodulesGrass import createModuleList
-
-
-__license__ = "GPLv3"
-__author__ = "Anika Bettge, Sören Gebbert"
-__copyright__ = "Copyright 2016-2018, Sören Gebbert and mundialis GmbH & Co. KG"
 
 
 def log_error_to_resource_logger(self, msg, rdc):

--- a/actinia_gdi/api/gdi_processing.py
+++ b/actinia_gdi/api/gdi_processing.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Copyright (c) 2018-present mundialis GmbH & Co. KG
+Copyright (c) 2018-2021 mundialis GmbH & Co. KG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ Extension of actinia_cores ephemeral_processing_with_export AsyncEphemeralExport
 
 __license__ = "Apache-2.0"
 __author__ = "Anika Bettge, Sören Gebbert"
-__copyright__ = "Copyright 2016-2018, Sören Gebbert and mundialis GmbH & Co. KG"
+__copyright__ = "Copyright 2016-2019, Sören Gebbert and mundialis GmbH & Co. KG"
 __maintainer__ = "mundialis"
 
 

--- a/actinia_gdi/api/gmodules/actinia.py
+++ b/actinia_gdi/api/gmodules/actinia.py
@@ -1,35 +1,35 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#######
-# actinia-core - an open source REST API for scalable, distributed, high
-# performance processing of geographical data that uses GRASS GIS for
-# computational tasks. For details, see https://actinia.mundialis.de/
-#
-# Copyright (c) 2016-2018 Sören Gebbert and mundialis GmbH & Co. KG
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
-#######
-
 """
+Copyright (c) 2018-present mundialis GmbH & Co. KG
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
 Process chain template management
 For now we only support read. In the future we want a whole CRUD.
 For now the templates are stored file based.
 
 * List all process chains templates
 * Describe single process chain template
-
 """
+
+__license__ = "Apache-2.0"
+__author__ = "Carmen Tawalika"
+__copyright__ = "Copyright 2019, mundialis"
+__maintainer__ = "Carmen Tawalika"
+
+
 from flask import jsonify, make_response
 from flask_restful_swagger_2 import swagger
 from flask_restful import Resource
@@ -40,12 +40,6 @@ from actinia_gdi.core.gmodulesActinia import createProcessChainTemplateList
 from actinia_gdi.core.gmodulesActinia import createActiniaModule
 from actinia_gdi.model.gmodules import ModuleList
 from actinia_gdi.model.responseModels import SimpleStatusCodeResponseModel
-
-
-__license__ = "GPLv3"
-__author__ = "Carmen Tawalika"
-__copyright__ = "Copyright 2019, mundialis"
-__maintainer__ = "Carmen Tawalika"
 
 
 class ListProcessChainTemplates(Resource):

--- a/actinia_gdi/api/gmodules/actinia.py
+++ b/actinia_gdi/api/gmodules/actinia.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Copyright (c) 2018-present mundialis GmbH & Co. KG
+Copyright (c) 2018-2021 mundialis GmbH & Co. KG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/actinia_gdi/api/gmodules/combined.py
+++ b/actinia_gdi/api/gmodules/combined.py
@@ -1,33 +1,33 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#######
-# actinia-core - an open source REST API for scalable, distributed, high
-# performance processing of geographical data that uses GRASS GIS for
-# computational tasks. For details, see https://actinia.mundialis.de/
-#
-# Copyright (c) 2016-2018 Sören Gebbert and mundialis GmbH & Co. KG
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
-#######
-
 """
+Copyright (c) 2018-present mundialis GmbH & Co. KG
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
 Module management and Process chain template management
 
 * List all modules + List all process chains templates
 * Describe single module + Describe single process chain template
-
 """
+
+__license__ = "Apache-2.0"
+__author__ = "Carmen Tawalika"
+__copyright__ = "Copyright 2019, mundialis"
+__maintainer__ = "Carmen Tawalika"
+
+
 from flask import jsonify, make_response
 from flask_restful_swagger_2 import swagger
 from flask_restful import Resource
@@ -39,12 +39,6 @@ from actinia_gdi.core.gmodulesActinia import createActiniaModule
 from actinia_gdi.core.gmodulesGrass import createModuleList, createGrassModule
 from actinia_gdi.model.gmodules import ModuleList
 from actinia_gdi.model.responseModels import SimpleStatusCodeResponseModel
-
-
-__license__ = "GPLv3"
-__author__ = "Carmen Tawalika"
-__copyright__ = "Copyright 2019, mundialis"
-__maintainer__ = "Carmen Tawalika"
 
 
 class ListVirtualModules(ResourceBase):

--- a/actinia_gdi/api/gmodules/combined.py
+++ b/actinia_gdi/api/gmodules/combined.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Copyright (c) 2018-present mundialis GmbH & Co. KG
+Copyright (c) 2018-2021 mundialis GmbH & Co. KG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/actinia_gdi/api/gmodules/grass.py
+++ b/actinia_gdi/api/gmodules/grass.py
@@ -1,34 +1,33 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#######
-# actinia-core - an open source REST API for scalable, distributed, high
-# performance processing of geographical data that uses GRASS GIS for
-# computational tasks. For details, see https://actinia.mundialis.de/
-#
-# Copyright (c) 2016-2018 Sören Gebbert and mundialis GmbH & Co. KG
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
-#######
-
 """
-Module management
+Copyright (c) 2018-present mundialis GmbH & Co. KG
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+Module management
 
 * List all modules
 * Describe single module
-
 """
+
+__license__ = "Apache-2.0"
+__author__ = "Anika Bettge, Carmen Tawalika"
+__copyright__ = "Copyright 2019, mundialis"
+__maintainer__ = "Anika Bettge, Carmen Tawalika"
+
+
 from flask import jsonify, make_response
 from flask_restful_swagger_2 import swagger
 from actinia_core.resources.resource_base import ResourceBase
@@ -37,12 +36,6 @@ from actinia_gdi.apidocs import gmodules
 from actinia_gdi.core.gmodulesGrass import createModuleList, createGrassModule
 from actinia_gdi.model.gmodules import ModuleList
 from actinia_gdi.model.responseModels import SimpleStatusCodeResponseModel
-
-
-__license__ = "GPLv3"
-__author__ = "Anika Bettge, Carmen Tawalika"
-__copyright__ = "Copyright 2019, mundialis"
-__maintainer__ = "Anika Bettge, Carmen Tawalika"
 
 
 class ListModules(ResourceBase):

--- a/actinia_gdi/api/gmodules/grass.py
+++ b/actinia_gdi/api/gmodules/grass.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Copyright (c) 2018-present mundialis GmbH & Co. KG
+Copyright (c) 2018-2021 mundialis GmbH & Co. KG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/actinia_gdi/core/gmodulesActinia.py
+++ b/actinia_gdi/core/gmodulesActinia.py
@@ -1,30 +1,30 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#######
-# actinia-core - an open source REST API for scalable, distributed, high
-# performance processing of geographical data that uses GRASS GIS for
-# computational tasks. For details, see https://actinia.mundialis.de/
-#
-# Copyright (c) 2016-2018 Sören Gebbert and mundialis GmbH & Co. KG
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
-#######
-
 """
+Copyright (c) 2018-present mundialis GmbH & Co. KG
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
 Module management related to process chain templates
-
 """
+
+__license__ = "Apache-2.0"
+__author__ = "Carmen Tawalika"
+__copyright__ = "Copyright 2019, mundialis"
+__maintainer__ = "Carmen Tawalika"
+
+
 import json
 from jinja2 import meta, nodes
 import re
@@ -34,12 +34,6 @@ from actinia_gdi.core.gmodulesParser import ParseInterfaceDescription
 from actinia_gdi.model.gmodules import Module
 from actinia_gdi.resources.templating import pcTplEnv
 from actinia_gdi.resources.logging import log
-
-
-__license__ = "GPLv3"
-__author__ = "Carmen Tawalika"
-__copyright__ = "Copyright 2019, mundialis"
-__maintainer__ = "Carmen Tawalika"
 
 
 def filter_func(name):

--- a/actinia_gdi/core/gmodulesActinia.py
+++ b/actinia_gdi/core/gmodulesActinia.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Copyright (c) 2018-present mundialis GmbH & Co. KG
+Copyright (c) 2018-2021 mundialis GmbH & Co. KG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/actinia_gdi/core/gmodulesGrass.py
+++ b/actinia_gdi/core/gmodulesGrass.py
@@ -1,30 +1,30 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#######
-# actinia-core - an open source REST API for scalable, distributed, high
-# performance processing of geographical data that uses GRASS GIS for
-# computational tasks. For details, see https://actinia.mundialis.de/
-#
-# Copyright (c) 2016-2018 Sören Gebbert and mundialis GmbH & Co. KG
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
-#######
-
 """
+Copyright (c) 2018-present mundialis GmbH & Co. KG
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
 Module management related to GRASS modules
-
 """
+
+__license__ = "Apache-2.0"
+__author__ = "Anika Bettge, Carmen Tawalika"
+__copyright__ = "Copyright 2019, mundialis"
+__maintainer__ = "Anika Bettge, Carmen Tawalika"
+
+
 import json
 import time
 
@@ -33,12 +33,6 @@ from actinia_core.resources.common.response_models import create_response_from_m
 from actinia_gdi.core.gmodulesProcessor import run_process_chain
 from actinia_gdi.core.gmodulesParser import ParseInterfaceDescription
 from actinia_gdi.model.gmodules import Module
-
-
-__license__ = "GPLv3"
-__author__ = "Anika Bettge, Carmen Tawalika"
-__copyright__ = "Copyright 2019, mundialis"
-__maintainer__ = "Anika Bettge, Carmen Tawalika"
 
 
 def createModuleList(self):

--- a/actinia_gdi/core/gmodulesGrass.py
+++ b/actinia_gdi/core/gmodulesGrass.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Copyright (c) 2018-present mundialis GmbH & Co. KG
+Copyright (c) 2018-2021 mundialis GmbH & Co. KG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/actinia_gdi/core/gmodulesParser.py
+++ b/actinia_gdi/core/gmodulesParser.py
@@ -1,30 +1,30 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#######
-# actinia-core - an open source REST API for scalable, distributed, high
-# performance processing of geographical data that uses GRASS GIS for
-# computational tasks. For details, see https://actinia.mundialis.de/
-#
-# Copyright (c) 2016-2018 Sören Gebbert and mundialis GmbH & Co. KG
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
-#######
-
 """
+Copyright (c) 2018-present mundialis GmbH & Co. KG
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
 Module management to parser GRASS xml response
-
 """
+
+__license__ = "Apache-2.0"
+__author__ = "Carmen Tawalika"
+__copyright__ = "Copyright 2019, mundialis"
+__maintainer__ = "Carmen Tawalika"
+
+
 import json
 import xmltodict
 
@@ -32,12 +32,6 @@ from actinia_gdi.model.gmodules import Module
 from actinia_gdi.model.gmodules import ModuleParameter, ModuleParameterSchema
 from actinia_gdi.resources.logging import log
 from actinia_gdi.resources.templating import tplEnv
-
-
-__license__ = "GPLv3"
-__author__ = "Carmen Tawalika"
-__copyright__ = "Copyright 2019, mundialis"
-__maintainer__ = "Carmen Tawalika"
 
 
 def logstring(module_id, param, key):

--- a/actinia_gdi/core/gmodulesParser.py
+++ b/actinia_gdi/core/gmodulesParser.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Copyright (c) 2018-present mundialis GmbH & Co. KG
+Copyright (c) 2018-2021 mundialis GmbH & Co. KG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/actinia_gdi/core/gmodulesProcessor.py
+++ b/actinia_gdi/core/gmodulesProcessor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Copyright (c) 2018-present mundialis GmbH & Co. KG
+Copyright (c) 2018-2021 mundialis GmbH & Co. KG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/actinia_gdi/core/gmodulesProcessor.py
+++ b/actinia_gdi/core/gmodulesProcessor.py
@@ -1,5 +1,22 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#######
+"""
+Copyright (c) 2018-present mundialis GmbH & Co. KG
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Code based on actinia_core: github.com/mundialis/actinia_core
+
 # actinia-core - an open source REST API for scalable, distributed, high
 # performance processing of geographical data that uses GRASS GIS for
 # computational tasks. For details, see https://actinia.mundialis.de/
@@ -19,12 +36,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-#######
 
-"""
+
 Module management to run GRASS tasks
-
 """
+
+__license__ = "Apache-2.0"
+__author__ = "Anika Bettge"
+__copyright__ = "Copyright 2019, mundialis"
+__maintainer__ = "Anika Bettge"
+
+
 import os
 import shutil
 import pickle
@@ -37,12 +59,6 @@ from actinia_core.resources.common.response_models import \
     ProcessingErrorResponseModel
 
 from actinia_gdi.core.common import start_job
-
-
-__license__ = "GPLv3"
-__author__ = "Anika Bettge"
-__copyright__ = "Copyright 2019, mundialis"
-__maintainer__ = "Anika Bettge"
 
 
 def initGrass(self):

--- a/actinia_gdi/resources/logging.py
+++ b/actinia_gdi/resources/logging.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Copyright (c) 2018-present mundialis GmbH & Co. KG
+Copyright (c) 2018-2021 mundialis GmbH & Co. KG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/actinia_gdi/resources/logging.py
+++ b/actinia_gdi/resources/logging.py
@@ -1,3 +1,30 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Copyright (c) 2018-present mundialis GmbH & Co. KG
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+Logging interface
+"""
+
+__license__ = "Apache-2.0"
+__author__ = "Carmen Tawalika"
+__copyright__ = "Copyright 2019, mundialis"
+__maintainer__ = "Carmen Tawalika"
+
+
 import logging
 from logging import FileHandler
 


### PR DESCRIPTION
During development some python file headers got mixed up. This PR unifies them while considering the license.